### PR TITLE
move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "jquery": ">=2.1.3",
-    "moment": ">=2.9.0",
-    "react": ">=0.12 || >=0.13.0-a"
+    "moment": ">=2.9.0"
   },
   "devDependencies": {
     "bootstrap": "^3.3.4",
@@ -35,6 +34,9 @@
     "jsxhint": "^0.14.0",
     "react-bootstrap": "^0.20.0",
     "reactify": "^1.1.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.12 || >=0.13.0-a"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Move `react` from `dependencies` to `peerDependencies`. Yarn 1.x has a bug that will install a wrong version of react (v16) when we install this repo by `"react-bootstrap-daterangepicker": "git://github.com/Unified/react-bootstrap-daterangepicker.git#55ad9eb97d8ba1aefc79cf6359f8e68f3b796833",
`.

The structure looks like this:
```
react-bootstrap-daterangepicker\
|--node_modules
|      |--react/ (v16)
|--package.json (dependencies: react 0.12)
```

We can move `react` peerDependencies so that npm/yarn will not install a react for `react-bootstrap-daterangepicker`.